### PR TITLE
Update the logic to avoid passing the interface

### DIFF
--- a/src/zcl_llm_tests_ollama.clas.abap
+++ b/src/zcl_llm_tests_ollama.clas.abap
@@ -8,11 +8,12 @@ CLASS zcl_llm_tests_ollama DEFINITION
 
   PROTECTED SECTION.
   PRIVATE SECTION.
+    DATA output TYPE string_table.
     METHODS:
-      so_complex IMPORTING out TYPE REF TO if_oo_adt_classrun_out,
-      simple_call IMPORTING out TYPE REF TO if_oo_adt_classrun_out,
-      so_simple IMPORTING out TYPE REF TO if_oo_adt_classrun_out,
-      multi_call IMPORTING out TYPE REF TO if_oo_adt_classrun_out.
+      so_complex,
+      simple_call,
+      so_simple,
+      multi_call.
 ENDCLASS.
 
 
@@ -30,23 +31,30 @@ CLASS zcl_llm_tests_ollama IMPLEMENTATION.
 
     DATA(response) = client->chat( request = request ).
 
-    IF response-success = abap_false.
-      out->write( |Error: return code { response-error-http_code } message { response-error-error_text }| ).
+    IF response-success = abap_false..
+      APPEND |Error: return code { response-error-http_code } message { response-error-error_text }| TO output.
       RETURN.
     ENDIF.
-    out->write( |Simple call result with { response-usage-prompt_tokens } input tokens and { response-usage-completion_tokens } output tokens.| ).
+    APPEND |Simple call result with { response-usage-prompt_tokens } input tokens and { response-usage-completion_tokens } output tokens.| TO output.
     LOOP AT response-choices INTO DATA(choice).
-      out->write( choice-message-content ).
+      APPEND choice-message-content TO output.
     ENDLOOP.
 
 
   ENDMETHOD.
 
   METHOD if_oo_adt_classrun~main.
-    simple_call( out ).
-    so_simple( out ).
-    so_complex( out ).
-    multi_call( out ).
+    "The following methods append the output to the output table. Due to compatibility issues
+    "over different releases passing around the out reference is an issue therefore we use this
+    "workaround.
+    simple_call( ).
+    so_simple( ).
+    so_complex( ).
+    multi_call( ).
+
+    LOOP AT output ASSIGNING FIELD-SYMBOL(<line>).
+      out->write( <line> ).
+    ENDLOOP.
   ENDMETHOD.
 
   METHOD so_simple.
@@ -83,17 +91,17 @@ CLASS zcl_llm_tests_ollama IMPLEMENTATION.
     DATA(response) = client->chat( request = request ).
 
     IF response-success = abap_false.
-      out->write( |Error: return code { response-error-http_code } message { response-error-error_text }| ).
+      APPEND |Error: return code { response-error-http_code } message { response-error-error_text }| TO output.
       RETURN.
     ENDIF.
     FIELD-SYMBOLS <dogs> TYPE any.
     ASSIGN response-structured_output->* TO <dogs>.
     dogs = <dogs>.
 
-    out->write( |Structured Output call result with { response-usage-prompt_tokens } input tokens and { response-usage-completion_tokens } output tokens.| ).
+    APPEND |Structured Output call result with { response-usage-prompt_tokens } input tokens and { response-usage-completion_tokens } output tokens.| TO output.
 
     LOOP AT dogs ASSIGNING FIELD-SYMBOL(<dog>).
-      out->write( |Breed: { <dog>-breed } Avg Age: { <dog>-avg_age } Avg Height: { <dog>-avg_height_cm } Size Category { <dog>-size_category }|  ).
+      APPEND |Breed: { <dog>-breed } Avg Age: { <dog>-avg_age } Avg Height: { <dog>-avg_height_cm } Size Category { <dog>-size_category }| TO output.
     ENDLOOP.
 
   ENDMETHOD.
@@ -139,17 +147,17 @@ CLASS zcl_llm_tests_ollama IMPLEMENTATION.
     DATA(response) = client->chat( request = request ).
 
     IF response-success = abap_false.
-      out->write( |Error: return code { response-error-http_code } message { response-error-error_text }| ).
+      APPEND |Error: return code { response-error-http_code } message { response-error-error_text }| TO output.
       RETURN.
     ENDIF.
     FIELD-SYMBOLS <dog> TYPE any.
     ASSIGN response-structured_output->* TO <dog>.
     dog = <dog>.
-    out->write( |Complex Structured Output result with { response-usage-prompt_tokens } input tokens and { response-usage-completion_tokens } output tokens.| ).
-    out->write( |Recommended breed: { dog-recommended_breed }| ).
-    out->write( |Reason: { dog-reason }| ).
+    APPEND |Complex Structured Output result with { response-usage-prompt_tokens } input tokens and { response-usage-completion_tokens } output tokens.| TO output.
+    APPEND |Recommended breed: { dog-recommended_breed }| TO output.
+    APPEND |Reason: { dog-reason }| TO output.
     LOOP AT dog-alternatives INTO DATA(alt).
-      out->write( |Alternative breed: { alt-breed }\nAdvantages: { alt-advantages }\nDisadvantages: { alt-disadvantages }\nDecision: { alt-decision }| ).
+      APPEND |Alternative breed: { alt-breed }\nAdvantages: { alt-advantages }\nDisadvantages: { alt-disadvantages }\nDecision: { alt-decision }| TO output.
     ENDLOOP.
 
   ENDMETHOD.
@@ -166,13 +174,13 @@ CLASS zcl_llm_tests_ollama IMPLEMENTATION.
 
     DATA(response) = client->chat( request = request ).
     IF response-success = abap_false.
-      out->write( |Error: return code { response-error-http_code } message { response-error-error_text }| ).
+      APPEND |Error: return code { response-error-http_code } message { response-error-error_text }| TO output.
       RETURN.
     ENDIF.
-    out->write( |First call with { response-usage-prompt_tokens } input tokens and { response-usage-completion_tokens } output tokens.| ).
-    out->write( `Response of first call to llm: ` ).
+    APPEND |First call with { response-usage-prompt_tokens } input tokens and { response-usage-completion_tokens } output tokens.| TO output.
+    APPEND `Response of first call to llm: ` TO output.
     LOOP AT response-choices INTO DATA(choice).
-      out->write( choice-message-content ).
+      APPEND choice-message-content TO output.
     ENDLOOP.
 
     "Switching to a different model taking over all history
@@ -184,16 +192,14 @@ CLASS zcl_llm_tests_ollama IMPLEMENTATION.
         content = |Now implement this in ABAP considering abap clean code principles. Avoid variable prefixes like lv_ and iv_.| ) TO qwen_request-messages.
     response = qwen_clnt->chat( request = qwen_request ).
     IF response-success = abap_false.
-      out->write( |Error: return code { response-error-http_code } message { response-error-error_text }| ).
+      APPEND |Error: return code { response-error-http_code } message { response-error-error_text }| TO output.
       RETURN.
     ENDIF.
-    out->write( |Second Call with { response-usage-prompt_tokens } input tokens and { response-usage-completion_tokens } output tokens.| ).
-    out->write( `Response of second call to llm: ` ).
+    APPEND |Second Call with { response-usage-prompt_tokens } input tokens and { response-usage-completion_tokens } output tokens.| TO output.
+    APPEND `Response of second call to llm: ` TO output.
     LOOP AT response-choices INTO choice.
-      out->write( choice-message-content ).
+      APPEND choice-message-content TO output.
     ENDLOOP.
 
-
   ENDMETHOD.
-
 ENDCLASS.

--- a/src/zcl_llm_tests_openai.clas.xml
+++ b/src/zcl_llm_tests_openai.clas.xml
@@ -5,7 +5,7 @@
    <VSEOCLASS>
     <CLSNAME>ZCL_LLM_TESTS_OPENAI</CLSNAME>
     <LANGU>E</LANGU>
-    <DESCRIPT>Test ollama models (live test)</DESCRIPT>
+    <DESCRIPT>Test OpenAI models (live test)</DESCRIPT>
     <STATE>1</STATE>
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>

--- a/src/zcl_llm_tests_openrouter.clas.xml
+++ b/src/zcl_llm_tests_openrouter.clas.xml
@@ -5,7 +5,7 @@
    <VSEOCLASS>
     <CLSNAME>ZCL_LLM_TESTS_OPENROUTER</CLSNAME>
     <LANGU>E</LANGU>
-    <DESCRIPT>Test ollama models (live test)</DESCRIPT>
+    <DESCRIPT>Test OpenRouter models (live test)</DESCRIPT>
     <STATE>1</STATE>
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>


### PR DESCRIPTION
Unfortunately based on the release the out of classrun is based on a different interface. Dynamic calls seem to lead to issues in the console so as a simple workaround I moved the output to the main method where you can directly use out. All entries are written to an internal string table before. As the console output is anyhow only at the end this should not have any relevant effect.